### PR TITLE
Fixes: crash bug: CallRemoteFunction

### DIFF
--- a/pawno/include/fader.inc
+++ b/pawno/include/fader.inc
@@ -132,9 +132,15 @@ public 	OnTextDrawFadeUpdate(Text:text, color, boxcolor, updaterate, displaytime
 			}
 		}
 	}
+	return 1;
 }
 
 forward OnTextDrawFadeComplete(Text:text, forplayerid);
+public OnTextDrawFadeComplete(Text:text, forplayerid)
+{
+	// The callback function must be implemented at least once, otherwise CallRemoteFunction makes the server act crazy...
+	return 1;
+}
 
 #if ! defined MAX_PLAYER_TEXT_DRAWS
 	#define MAX_PLAYER_TEXT_DRAWS (256)
@@ -222,8 +228,14 @@ public 	OnPlayerTextDrawFadeUpdate(playerid, PlayerText:text, color, boxcolor, u
 			}
 		}
 	}
+	return 1;
 }
 
 forward OnPlayerTextDrawFadeComplete(playerid, PlayerText:text);
+public OnPlayerTextDrawFadeComplete(playerid, PlayerText:text)
+{
+	// The callback function must be implemented at least once, otherwise CallRemoteFunction makes the server act crazy...
+	return 1;
+}
 
 #undef ALPHA


### PR DESCRIPTION
The server would crash/freeze if you never used OnPlayerTextDrawFadeComplete and/or OnTextDrawFadeComplete
